### PR TITLE
optimize member assuming ranges remain ordered

### DIFF
--- a/Data/RangeSet/List.hs
+++ b/Data/RangeSet/List.hs
@@ -96,8 +96,9 @@ null = Prelude.null . toRangeList
 
 -- | /O(n)/. Is the element in the set?
 member :: (Ord a, Enum a) => a -> RSet a -> Bool
-member x (RSet xs) = any f xs
+member x (RSet xs) = any f $ takeWhile g xs
   where f (a, b) = a <= x && x <= b
+        g (_, b) = x <= b
 
 -- | /O(n)/. Is the element not in the set?
 notMember :: (Ord a, Enum a) => a -> RSet a -> Bool

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -114,9 +114,18 @@ rangeToRSet (RAIntersection a b)  = RSet.intersection (rangeToRSet a) (rangeToRS
 rangeProp :: RSetAction Int8 -> Bool
 rangeProp seta = Set.elems (rangeToSet seta) == RSet.elems (rangeToRSet seta)
 
+ordered :: Ord a => [(a,a)] -> Bool
+ordered rs = all lt $ zip rs (tail rs)
+  where
+    lt :: Ord a => ((a,a),(a,a)) -> Bool
+    lt ((_,y),(u,_)) = y < u
+
+orderedProp :: RSetAction Int8 -> Bool
+orderedProp = ordered . RSet.toRangeList . rangeToRSet
 
 qcProps :: TestTree
 qcProps = testGroup "QuickCheck properties"
   [ QC.testProperty "element operations similar" elementsProp
   , QC.testProperty "range operations similar" rangeProp
+  , QC.testProperty "ranges remain ordered" orderedProp
   ]


### PR DESCRIPTION
Nice module and it inspired me to play around with it. Feel free to include these changes or not.
