### PR TITLE
Fix upper bounds on tasty dependency

### DIFF
--- a/range-set-list.cabal
+++ b/range-set-list.cabal
@@ -70,7 +70,7 @@ test-suite test
     , deepseq
     , hashable
     , range-set-list
-    , tasty             >=0.8 && <1.4
+    , tasty             >=0.8 && <=1.4.2
     , tasty-quickcheck  >=0.8 && <0.11
 
   if !impl(ghc >=8.0)

--- a/range-set-list.cabal
+++ b/range-set-list.cabal
@@ -70,7 +70,7 @@ test-suite test
     , deepseq
     , hashable
     , range-set-list
-    , tasty             >=0.8 && <=1.4.2
+    , tasty             >=0.8 && <1.4.2
     , tasty-quickcheck  >=0.8 && <0.11
 
   if !impl(ghc >=8.0)


### PR DESCRIPTION
Raises upper bound on `tasty` to `1.4.2`, fixes #21.